### PR TITLE
Looking for ID selector, also try 'attrs'

### DIFF
--- a/src/language.js
+++ b/src/language.js
@@ -16,6 +16,9 @@ LanguageSpecification.prototype.id = function id(vNode) {
   if (vNode.data && vNode.data.props && vNode.data.props.id) {
     return vNode.data.props.id
   }
+  else if (vNode.data && vNode.data.attrs && vNode.data.attrs.id) {
+    return vNode.data.attrs.id
+  }
   return selectorParser(vNode.sel).id
 }
 


### PR DESCRIPTION
When looking for an ID selector, also look under the 'attrs' property under data. 

One situation this is pertinent is when an HTML string is converted to a virtual node element using snabbdom-virtualize, because that’s where the ‘id’ is put, rather than under 'props' or as a subcomponent of the ‘sel’ property.

Here’s an example: http://esnextb.in/?gist=6925dadd072ae88859f15182bd7cc6d6