### PR TITLE
Falsy children

### DIFF
--- a/src/findMatches.ts
+++ b/src/findMatches.ts
@@ -47,7 +47,7 @@ function traverseVNode (vNode: VNode,
     for (let i = 0; i < length; ++i) {
       const { children } = currentNode;
 
-      if (children && typeof children[i] !== 'string') {
+      if (children && children[i] && typeof children[i] !== 'string') {
         const child = children[i];
         recurse(child as VNode, false, currentNode);
       }

--- a/test/index.ts
+++ b/test/index.ts
@@ -143,7 +143,7 @@ describe('select', () => {
       assert.strictEqual(result[0].sel, 'h2.thunk');
     });
 
-    describe('psuedo-selector', () => {
+    describe('pseudo-selector', () => {
       it('should match using `:first-child`', () => {
         const vNode = div([
           h('p.foo', {}, []),

--- a/test/index.ts
+++ b/test/index.ts
@@ -22,6 +22,11 @@ describe('select', () => {
   });
 
   describe('given a selector and a VNode', () => {
+
+    it('should ignore falsy children', () => {
+      assert.ok(select('', h('div', [, h('div')])));
+    });
+
     it('should return an array of matching vNodes', () => {
       const vNode = h('div', {}, [
         h('h1.matches', {}, []),


### PR DESCRIPTION
Fix case where an children is `undefined` in the vNode tree.

This will fix #15 