### PR TITLE
use a Symbol for VNode.parent

### DIFF
--- a/src/findMatches.ts
+++ b/src/findMatches.ts
@@ -1,5 +1,6 @@
 import { VNode } from 'snabbdom/vnode';
 import { language } from './language';
+import parentSymbol from './parent-symbol';
 
 export function findMatches (cssSelector: string, vNode: VNode): Array<VNode> {
   const selector = language(cssSelector);
@@ -66,7 +67,9 @@ function addParent (vNode: VNode, isParent: boolean, parent?: VNode): void {
     vNode.data = {};
   }
 
-  if (!(vNode.data as any).parent) {
-    (vNode.data as any).parent = parent;
+  if (!vNode.data[parentSymbol]) {
+    Object.defineProperty(vNode.data, parentSymbol, {
+      value: parent,
+    });
   }
 }

--- a/src/language.ts
+++ b/src/language.ts
@@ -2,13 +2,14 @@ import cssauron from 'cssauron2';
 import { VNode } from 'snabbdom/vnode';
 import { selectorParser } from './selectorParser';
 import { classNameFromVNode } from './classNameFromVNode';
+import parentSymbol from './parent-symbol';
 
 export const language = cssauron({
   tag: (vNode: VNode) => selectorParser(vNode).tagName,
   class: (vNode: VNode) => classNameFromVNode(vNode),
   id: (vNode: VNode) => selectorParser(vNode).id,
   children: (vNode: VNode) => vNode.children || [],
-  parent: (vNode: VNode) => (vNode.data as any).parent || vNode,
+  parent: (vNode: VNode) => (vNode.data as any)[parentSymbol] || vNode,
   contents: (vNode: VNode) => vNode.text,
   attr (vNode: VNode, attr: string) {
     if (vNode.data) {

--- a/src/parent-symbol.ts
+++ b/src/parent-symbol.ts
@@ -1,0 +1,3 @@
+const parentSymbol: symbol = Symbol('parent');
+
+export default parentSymbol;

--- a/test/index.ts
+++ b/test/index.ts
@@ -186,5 +186,21 @@ describe('select', () => {
         assert.strictEqual(result[0].text, '29');
       });
     });
+
+    it('should not mutate the vNode tree visibly', () => {
+      const tree1 = h('div', {}, [
+        h('h1.matches', {}, []),
+        h('h2.nomatches', {}, []),
+        h('h3.matches', {}, []),
+      ]);
+      const tree2 = h('div', {}, [
+        h('h1.matches', {}, []),
+        h('h2.nomatches', {}, []),
+        h('h3.matches', {}, []),
+      ]);
+
+      select('h1', tree1);
+      assert.deepStrictEqual(tree1, tree2);
+    });
   });
 });


### PR DESCRIPTION
Hey!

I discovered that `snabbdom-selector` mutates every `VNode` in the tree when traversing. Aside from being considered bad practice, this breaks deep equal comparisons, e.g. in tests.

**This PR changes the code to use a [`Symbol`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) instead.** Because code might depend on the previous plain `parent` property in some way, **this is a breaking change**.