### PR TITLE
Mark curry function as pure

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:cjs": "tsc -P tsconfig.json --module commonjs",
     "build:es6": "tsc -P tsconfig.json --module es6 --outDir lib/es6",
     "build": "npm run build:cjs && npm run build:es6",
+    "postbuild": "sed -i -e 's/curry2(/\\/*@__PURE__*\\/curry2(/g' lib/es6/index.js",
     "prepublish": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
Fixes #25 
I did a quick test with the one-fits-all flavor and this reduces the bundle size from `89.7 KiB` to `88.4 KiB`. Not much, but it's something.

Normally I would have just added a comment in the source, but i was not able to get the typescript compiler to not erase it.